### PR TITLE
Fix trailing comma on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "utility",
     "ai",
     "artificial intelligence",
-    "statejs",
+    "statejs"
   ],
   "author": "Renato Pereira <renato.ppontes@gmail.com> (http://guineashots.com/)",
   "license": "MIT",


### PR DESCRIPTION
Fixed trailing comma on `package.json` that was causing `npm install` to fail
